### PR TITLE
Alter indexmanipulation logic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockTensorKit"
 uuid = "5f87ffc2-9cf1-4a46-8172-465d160bd8cd"
 authors = ["Lukas Devos <ldevos98@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -41,7 +41,7 @@ function TK.add_transform!(
     for (I, v) in nonzero_pairs(tsrc)
         I′ = CartesianIndex(TT.getindices(I.I, p))
         tdst[I′] = TK.add_transform!(
-            tdst[I′], v, (p₁, p₂), fusiontreetransform, α, one(scalartype(tdst)), backend...
+            tdst[I′], v, (p₁, p₂), fusiontreetransform, α, One(), backend...
         )
     end
     return tdst
@@ -65,7 +65,7 @@ function TK.add_transform!(
     for (I, v) in nonzero_pairs(tsrc)
         I′ = CartesianIndex(TT.getindices(I.I, p))
         tdst[I′] = TK.add_transform!(
-            tdst[I′], v, (p₁, p₂), fusiontreetransform, α, one(scalartype(tdst)), backend...
+            tdst[I′], v, (p₁, p₂), fusiontreetransform, α, One(), backend...
         )
     end
     return tdst
@@ -83,4 +83,163 @@ function TK.add_transform!(
     return TK.add_transform!(
         tdst, only(tsrc), (p₁, p₂), fusiontreetransform, α, β, backend...
     )
+end
+
+# we need to capture the other functions earlier to enjoy the fast transformers...
+for f! in (:add_permute!, :add_transpose!)
+    @eval function TK.$f!(
+        tdst::BlockTensorMap,
+        tsrc::BlockTensorMap,
+        (p₁, p₂)::Index2Tuple{N₁,N₂},
+        α::Number,
+        β::Number,
+        backend::AbstractBackend...,
+    ) where {N₁,N₂}
+        @boundscheck begin
+            permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+                throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+                dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+        end
+        dstdata = parent(tdst)
+        srcdata = permutedims(StridedView(parent(tsrc)), (p₁..., p₂...))
+
+        @inbounds for I in eachindex(dstdata, srcdata)
+            dstdata[I] = TK.$f!(dstdata[I], srcdata[I], (p₁, p₂), α, β, backend...)
+        end
+        return tdst
+    end
+    @eval function TK.$f!(
+        tdst::AbstractBlockTensorMap,
+        tsrc::AbstractBlockTensorMap,
+        (p₁, p₂)::Index2Tuple{N₁,N₂},
+        α::Number,
+        β::Number,
+        backend::AbstractBackend...,
+    ) where {N₁,N₂}
+        @boundscheck begin
+            permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+                throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+                dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+        end
+        scale!(tdst, β)
+        p = (p₁..., p₂...)
+        for (I, v) in nonzero_pairs(tsrc)
+            I′ = CartesianIndex(TT.getindices(I.I, p))
+            tdst[I′] = TK.$f!(tdst[I′], v, (p₁, p₂), α, One(), backend...)
+        end
+        return tdst
+    end
+    @eval function TK.$f!(
+        tdst::AbstractBlockTensorMap,
+        tsrc::AdjointTensorMap{T,S,N₁,N₂,TT},
+        (p₁, p₂)::Index2Tuple,
+        α::Number,
+        β::Number,
+        backend::AbstractBackend...,
+    ) where {T,S,N₁,N₂,TT<:AbstractBlockTensorMap}
+        @boundscheck begin
+            permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+                throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+                dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+        end
+        scale!(tdst, β)
+        p = (p₁..., p₂...)
+        for (I, v) in nonzero_pairs(tsrc)
+            I′ = CartesianIndex(TT.getindices(I.I, p))
+            tdst[I′] = TK.$f!(tdst[I′], v, (p₁, p₂), α, One(), backend...)
+        end
+        return tdst
+    end
+    @eval function TK.$f!(
+        tdst::TensorMap,
+        tsrc::BlockTensorMap,
+        (p₁, p₂)::Index2Tuple,
+        α::Number,
+        β::Number,
+        backend::AbstractBackend...,
+    )
+        @assert length(tsrc) == 1 "source tensor must be a single tensor"
+        return TK.$f!(tdst, only(tsrc), (p₁, p₂), α, β, backend...)
+    end
+end
+
+function TK.add_braid!(
+    tdst::BlockTensorMap,
+    tsrc::BlockTensorMap,
+    (p₁, p₂)::Index2Tuple{N₁,N₂},
+    levels::IndexTuple,
+    α::Number,
+    β::Number,
+    backend::AbstractBackend...,
+) where {N₁,N₂}
+    @boundscheck begin
+        permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+            throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+            dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+    end
+    dstdata = parent(tdst)
+    srcdata = permutedims(StridedView(parent(tsrc)), (p₁..., p₂...))
+
+    @inbounds for I in eachindex(dstdata, srcdata)
+        dstdata[I] = TK.add_braid!(
+            dstdata[I], srcdata[I], (p₁, p₂), levels, α, β, backend...
+        )
+    end
+    return tdst
+end
+function TK.add_braid!(
+    tdst::AbstractBlockTensorMap,
+    tsrc::AbstractBlockTensorMap,
+    (p₁, p₂)::Index2Tuple{N₁,N₂},
+    levels::IndexTuple,
+    α::Number,
+    β::Number,
+    backend::AbstractBackend...,
+) where {N₁,N₂}
+    @boundscheck begin
+        permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+            throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+            dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+    end
+    scale!(tdst, β)
+    p = (p₁..., p₂...)
+    for (I, v) in nonzero_pairs(tsrc)
+        I′ = CartesianIndex(TT.getindices(I.I, p))
+        tdst[I′] = TK.add_braid!(tdst[I′], v, (p₁, p₂), levels, α, One(), backend...)
+    end
+    return tdst
+end
+function TK.add_braid!(
+    tdst::AbstractBlockTensorMap,
+    tsrc::AdjointTensorMap{T,S,N₁,N₂,TT},
+    (p₁, p₂)::Index2Tuple,
+    levels::IndexTuple,
+    α::Number,
+    β::Number,
+    backend::AbstractBackend...,
+) where {T,S,N₁,N₂,TT<:AbstractBlockTensorMap}
+    @boundscheck begin
+        permute(space(tsrc), (p₁, p₂)) == space(tdst) ||
+            throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),
+            dest = $(codomain(tdst))←$(domain(tdst)), p₁ = $(p₁), p₂ = $(p₂)"))
+    end
+    scale!(tdst, β)
+    p = (p₁..., p₂...)
+    for (I, v) in nonzero_pairs(tsrc)
+        I′ = CartesianIndex(TT.getindices(I.I, p))
+        tdst[I′] = TK.add_braid!(tdst[I′], v, (p₁, p₂), levels, α, One(), backend...)
+    end
+    return tdst
+end
+function TK.add_braid!(
+    tdst::TensorMap,
+    tsrc::BlockTensorMap,
+    (p₁, p₂)::Index2Tuple,
+    levels::IndexTuple,
+    α::Number,
+    β::Number,
+    backend::AbstractBackend...,
+)
+    @assert length(tsrc) == 1 "source tensor must be a single tensor"
+    return TK.add_braid!(tdst, only(tsrc), (p₁, p₂), levels, α, β, backend...)
 end


### PR DESCRIPTION
The previous implementation tried to intercept the methods only at the level of `add_transform!`, at which point the efficient `fusiontreetransform` for `TensorMap` should have already been present. As a result, we were missing out on that and hitting a generic fallback.
Here, I intercept higher up the call stack, resulting in (hopefully) improved performance.