### PR TITLE
Fix creation of dense similar for linalg

### DIFF
--- a/src/auxiliary/blockarrays.jl
+++ b/src/auxiliary/blockarrays.jl
@@ -1,3 +1,12 @@
+similar_dense(::Type{Vector{T}}, sz::NTuple{N, Ti}) where {T, N, Ti} = Array{T, N}(undef, sz)
+similar_dense(::Type{TA}, sz) where {T, N, P, TA <: Base.SubArray{T, N, P}} = similar_dense(P, sz)
+similar_dense(::Type{TA}, sz) where {T, N, P, TA <: Base.ReshapedArray{T, N, P}} = similar_dense(P, sz)
+similar_dense(::Type{TA}, sz) where {T, N, TA <: AbstractArray{T, N}} = TA(undef, sz)
+function similar_dense(A::BlockMatrix{T, R}) where {T, R}
+    Adense = similar_dense(eltype(R), size(A))
+    return Adense
+end
+
 function copy_dense!(Adense, A)
     for block_index in Iterators.product(blockaxes(A)...)
         a = view(A, block_index...)

--- a/src/auxiliary/blockarrays.jl
+++ b/src/auxiliary/blockarrays.jl
@@ -1,4 +1,4 @@
-similar_dense(::Type{Vector{T}}, sz::NTuple{N, Ti}) where {T, N, Ti} = Array{T, N}(undef, sz)
+similar_dense(::Type{Vector{T}}, sz::Dims{N}) where {T, N} = Array{T, N}(undef, sz)
 similar_dense(::Type{TA}, sz) where {T, N, P, TA <: Base.SubArray{T, N, P}} = similar_dense(P, sz)
 similar_dense(::Type{TA}, sz) where {T, N, P, TA <: Base.ReshapedArray{T, N, P}} = similar_dense(P, sz)
 similar_dense(::Type{TA}, sz) where {T, N, TA <: AbstractArray{T, N}} = TA(undef, sz)

--- a/src/linalg/factorizations.jl
+++ b/src/linalg/factorizations.jl
@@ -25,7 +25,8 @@ for f! in (
     )
     @eval function MAK.$f!(t::AbstractBlockTensorMap, F, alg::AbstractAlgorithm)
         TensorKit.foreachblock(t, F...) do _, (tblock, Fblocks...)
-            Fblocks′ = MAK.$f!(copy_dense!(similar(tblock, size(tblock)), tblock), alg)
+            dense_block = similar_dense(tblock)
+            Fblocks′ = MAK.$f!(copy_dense!(dense_block, tblock), alg)
             # deal with the case where the output is not in-place
             for (b′, b) in zip(Fblocks′, Fblocks)
                 b === b′ || copy!(b, b′)
@@ -44,7 +45,8 @@ for f! in (
     )
     @eval function MAK.$f!(t::AbstractBlockTensorMap, N, alg::AbstractAlgorithm)
         TensorKit.foreachblock(t, N) do _, (tblock, Nblock)
-            Nblock′ = MAK.$f!(copy_dense!(similar(tblock, size(tblock)), tblock), alg)
+            dense_block = similar_dense(tblock)
+            Nblock′ = MAK.$f!(copy_dense!(dense_block, tblock), alg)
             # deal with the case where the output is not the same as the input
             Nblock === Nblock′ || copy!(Nblock, Nblock′)
             return nothing


### PR DESCRIPTION
I *think* this should fix this for GPU arrays. It would be helpful to set up a build kite pipeline/JLArrays tests for this package at some point. Anyway, this is a bit ugly, but since the needed `similar(::Type{TA},...)` methods in Base aren't available on 1.10 and 1.12, it seemed like the simplest way...