### PR TITLE
fix: `one!` implementation for non-matching block partitions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockTensorKit"
 uuid = "5f87ffc2-9cf1-4a46-8172-465d160bd8cd"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Lukas Devos <ldevos98@gmail.com> and contributors"]
 
 [deps]

--- a/src/auxiliary/blockarrays.jl
+++ b/src/auxiliary/blockarrays.jl
@@ -27,9 +27,13 @@ function MAK.zero!(A::BlockBlasMat)
 end
 
 function MAK.one!(A::BlockBlasMat)
+    rowaxis, colaxis = axes(A)
     for bj in blockaxes(A, 2), bi in blockaxes(A, 1)
         a = view(A, bi, bj)
-        bi == bj ? MAK.one!(a) : MAK.zero!(a)
+        MAK.zero!(a)
+        isempty(a) && continue
+        k = first(rowaxis[bi]) - first(colaxis[bj])
+        view(a, MAK.diagind(a, k)) .= one(eltype(a))
     end
     return A
 end

--- a/test/abstracttensor/blocktensor.jl
+++ b/test/abstracttensor/blocktensor.jl
@@ -152,6 +152,24 @@ end
     end
 end
 
+@testset "one!/isomorphism with mismatched block partitions" begin
+    # regression test: codomain and domain are isomorphic but partitioned differently
+    # (Vflat has a single block, Vsum decomposes into two), which used to confuse
+    # MAK.one!'s block-diagonal detection
+    W1 = Rep[U₁](0 => 2, 1 => 1)
+    W2 = Rep[U₁](0 => 2, 1 => 1)
+    Vsum = W1 ⊞ W2
+    Vflat = oplus(Vsum)
+
+    for T in (Float64, ComplexF64), A in (Vector{T}, JLVector{T})
+        u = @constinferred unitary(A, Vflat, Vsum)
+        @test storagetype(u) == A
+        @test u' * u ≈ id(A, Vsum)
+        @test only(u * u') ≈ id(A, Vflat)
+        @test isunitary(u)
+    end
+end
+
 @testset "Basic linear algebra: test via conversion" begin
     W = V1 ⊗ V2 ⊗ V3 ← V4 ⊗ V5
     for T in (Float32, ComplexF64)


### PR DESCRIPTION
Fixes #63 