### PR TITLE
Fix `BraidingTensor` not passing all parameters

### DIFF
--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -118,13 +118,14 @@ end
 function TK.BraidingTensor{T, S}(
         V1::SumSpace{S}, V2::SumSpace{S}, adjoint::Bool = false
     ) where {T, S}
-    τtype = BraidingTensor{T, S}
-    tdst = SparseBlockTensorMap{τtype}(undef, V2 ⊗ V1, V1 ⊗ V2)
+    τtype = TK.braidingtensortype(S, T)
+    cod, dom = adjoint ? (V1 ⊗ V2, V2 ⊗ V1) : (V2 ⊗ V1, V1 ⊗ V2)
+    tdst = SparseBlockTensorMap{τtype}(undef, cod, dom)
     Vs = eachspace(tdst)
     @inbounds for I in CartesianIndices(tdst)
         if I[1] == I[4] && I[2] == I[3]
             V = Vs[I]
-            tdst[I] = TK.BraidingTensor{T, S}(V[2], V[1], adjoint)
+            tdst[I] = adjoint ? τtype(V[1], V[2], true) : τtype(V[2], V[1], false)
         end
     end
     return tdst

--- a/test/abstracttensor/braidingtensor.jl
+++ b/test/abstracttensor/braidingtensor.jl
@@ -1,0 +1,36 @@
+using Test
+using TestExtras
+using TensorKit
+using BlockTensorKit
+using Random
+
+Random.seed!(1234)
+
+@testset "BraidingTensor with SumSpace: $(sectortype(V))" for V in (
+        ℂ^2, Vect[Z2Irrep](0 => 1, 1 => 1), Vect[FibonacciAnyon](:I => 1, :τ => 1),
+    )
+    V1, V2 = V, V ⊕ V # V1 != V2 to test adjoint
+    S1, S2 = SumSpace(V1), SumSpace(V2)
+    τ = @constinferred BraidingTensor(S1, S2)
+
+    @test codomain(τ) == S2 ⊗ S1
+    @test domain(τ) == S1 ⊗ S2
+    @test TensorMap(τ[1, 1, 1, 1]) ≈ TensorMap(BraidingTensor(V1, V2))
+
+    t = TensorMap(τ)
+    @test t' * t ≈ id(domain(t))
+    τ_adj = @constinferred BraidingTensor(S1, S2, true)
+    @test codomain(τ_adj) == S1 ⊗ S2
+    @test domain(τ_adj) == S2 ⊗ S1
+    @test TensorMap(τ_adj) ≈ t'
+
+    # agree with TensorKit's `braid`
+    Sa, Sb, W = SumSpace(V1, V2), SumSpace(V2), SumSpace(V1)
+    x = randn(ComplexF64, Sa ⊗ Sb, W)
+    τm = @constinferred BraidingTensor(Sa, Sb)
+    @plansor y[-1 -2; -3] := τm[-1 -2; 1 2] * x[1 2; -3]
+    @test y ≈ braid(x, ((2, 1), (3,)), (1, 2, 3))
+    if !(BraidingStyle(sectortype(V)) isa SymmetricBraiding)
+        @test !(y ≈ braid(x, ((2, 1), (3,)), (2, 1, 3)))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,9 @@ const GROUP = uppercase(
         @time @safetestset "SparseBlockTensor" begin
             include("abstracttensor/sparseblocktensor.jl")
         end
+        @time @safetestset "BraidingTensor" begin
+            include("abstracttensor/braidingtensor.jl")
+        end
     end
 
     if GROUP == "ALL" || GROUP == "LINALG"


### PR DESCRIPTION
I think ultimately within current MPSKit this change doesn't matter, because the `planar` macro will use `braidingtensortype` which passes the 3 parameters.